### PR TITLE
EASY-2428: refactor and extend tests

### DIFF
--- a/src/test/scala/nl/knaw/dans/easy/licenses/LicenseJsonFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/LicenseJsonFixture.scala
@@ -15,11 +15,19 @@
  */
 package nl.knaw.dans.easy.licenses
 
-class LicensesJsonSpec extends LicenseJsonFixture {
+import java.io.File
 
-  "all the files in licenses.json" should "be present in the licenses directory and vice versa" in {
-    jsonMap.values
-      .map(_.viewName)
-      .toSeq.sortBy(identity) shouldBe documentBaseFileNames
-  }
+import org.json4s.Extraction.extract
+import org.json4s.JsonAST.JObject
+import org.json4s.native.JsonMethods.parse
+import org.json4s.{ DefaultFormats, Formats }
+
+case class Item(title: String, viewName: String)
+
+class LicenseJsonFixture extends TestFixture {
+  implicit val jsonFormats: Formats = new DefaultFormats {}
+
+  val jsonMap: Map[String, Item] = parse(new File(LICENSES_DIR, "licenses.json"))
+    .asInstanceOf[JObject].obj
+    .map { case (url, value) => url -> extract[Item](value) }.toMap
 }

--- a/src/test/scala/nl/knaw/dans/easy/licenses/LicensesJsonSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/LicensesJsonSpec.scala
@@ -19,25 +19,16 @@ import java.io.File
 
 import org.json4s._
 import org.json4s.native.JsonMethods._
-import org.scalatest.{ FlatSpec, Inspectors, Matchers }
 
-class LicensesJsonSpec extends FlatSpec with Matchers with Inspectors {
-
-  private val LICENSES_DIR = "src/main/resources/licenses"
-  private val files = new File(LICENSES_DIR).listFiles.filter(_.isFile).map(_.getName).filterNot(n => n.endsWith("properties") || n.endsWith("json")).toList
-  private val fileNames = files.map(f => f.substring(0, f.lastIndexOf(".")))
+class LicensesJsonSpec extends TestFixture {
+  implicit val jsonFormats: Formats = new DefaultFormats {}
   private val json = parse(new File(LICENSES_DIR, "licenses.json"))
   private val viewNames = for {
     JObject(file) <- json
     JField("title", viewName) <- file
-  } yield viewName.values
+  } yield Extraction.extract[String](viewName)
 
-  "all the files in licenses.json" should "be present in the licenses directory" in {
-    forEvery(viewNames) { fileNames should contain(_) }
-  }
-
-  "all the files in licenses directory (except .properties and .json files)" should "be present in the licenses.json file" in {
-    fileNames.foreach(viewNames should contain(_))
-    forEvery(fileNames) { viewNames should contain(_) }
+  "all the files in licenses.json" should "be present in the licenses directory and vice versa" in {
+    viewNames.sortBy(identity) shouldBe baseFileNames
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/licenses/LicensesPropertiesSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/LicensesPropertiesSpec.scala
@@ -32,7 +32,7 @@ class LicensesPropertiesSpec extends PropsFixture {
     propBaseFileNames shouldBe documentBaseFileNames
   }
 
-  "the specified extension in licenses.properties" should "exist in the licenses directory" in {
+  "a file with extension specified in licenses.properties" should "exist in the licenses directory" in {
     forEvery(propFiles) { fileName => file(fileName) should exist }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/licenses/LicensesPropertiesSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/LicensesPropertiesSpec.scala
@@ -17,23 +17,30 @@ package nl.knaw.dans.easy.licenses
 
 import java.io.File
 
-import org.apache.commons.configuration.PropertiesConfiguration
-import org.scalatest.{ FlatSpec, Inspectors, Matchers }
-
 import scala.collection.JavaConverters._
 
-class LicensesPropertiesSpec extends FlatSpec with Matchers with Inspectors {
+class LicensesPropertiesSpec extends PropsFixture {
 
-  private val LICENSES_DIR = "src/main/resources/licenses"
-  private val files = new File(LICENSES_DIR).listFiles.filter(_.isFile).map(_.getName).filterNot(n => n.endsWith("properties") || n.endsWith("json")).toList
-  private val props = new PropertiesConfiguration(LICENSES_DIR + "/licenses.properties")
-  private val propValues = props.getKeys.asScala.map(key => props.getString(key)).toList
+  private val propFiles: Seq[String] = props.getKeys.asScala
+    .map(key => props.getString(key))
+    .toSeq
+  val propBaseFileNames: Seq[String] = propFiles
+    .map(stripExtension)
+    .sortBy(identity).distinct
 
-  "all the files in licenses.properties" should "be present in the licenses directory" in {
-    forEvery(propValues) { files should contain(_) }
+  "all the files in licenses.properties" should "be present in the licenses directory and vice versa" in {
+    propBaseFileNames shouldBe documentBaseFileNames
   }
 
-  "all the files in licenses directory (except .properties and .json files)" should "be present in the licenses.properties file" in {
-    forEvery(files) { propValues should contain(_) }
+  "the specified extension in licenses.properties" should "exist in the licenses directory" in {
+    forEvery(propFiles) { fileName => file(fileName) should exist }
+  }
+
+  "all license files" should "have a text version" in pendingUntilFixed { // used by easy-deposit-agreement-creator
+    forEvery(propBaseFileNames) { baseFileName => file(s"$baseFileName.txt") should exist }
+  }
+
+  private def file(fileName: String) = {
+    new File(LICENSES_DIR, fileName)
   }
 }

--- a/src/test/scala/nl/knaw/dans/easy/licenses/LicensesPropertiesSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/LicensesPropertiesSpec.scala
@@ -36,7 +36,7 @@ class LicensesPropertiesSpec extends PropsFixture {
     forEvery(propFiles) { fileName => file(fileName) should exist }
   }
 
-  "all license files" should "have a text version" in pendingUntilFixed { // used by easy-deposit-agreement-creator
+  "all license files" should "have a text version" in { // used by easy-deposit-agreement-creator
     forEvery(propBaseFileNames) { baseFileName => file(s"$baseFileName.txt") should exist }
   }
 

--- a/src/test/scala/nl/knaw/dans/easy/licenses/PropsFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/PropsFixture.scala
@@ -15,11 +15,10 @@
  */
 package nl.knaw.dans.easy.licenses
 
-class LicensesJsonSpec extends LicenseJsonFixture {
+import java.io.File
 
-  "all the files in licenses.json" should "be present in the licenses directory and vice versa" in {
-    jsonMap.values
-      .map(_.viewName)
-      .toSeq.sortBy(identity) shouldBe documentBaseFileNames
-  }
+import org.apache.commons.configuration.PropertiesConfiguration
+
+trait PropsFixture extends TestFixture {
+  val props = new PropertiesConfiguration(new File(LICENSES_DIR, "licenses.properties"))
 }

--- a/src/test/scala/nl/knaw/dans/easy/licenses/TestFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/TestFixture.scala
@@ -1,0 +1,18 @@
+package nl.knaw.dans.easy.licenses
+
+import java.io.File
+
+import org.scalatest.{ FlatSpec, Inspectors, Matchers }
+
+trait TestFixture extends FlatSpec with Matchers with Inspectors  {
+  val LICENSES_DIR = "src/main/resources/licenses"
+  val extensionRegExp = ".[^.]+$"
+  val licenseFiles: List[String] = new File(LICENSES_DIR)
+    .listFiles.filter(_.isFile).map(_.getName)
+    .filterNot(n => n.endsWith("properties") || n.endsWith("json"))
+    .toList
+  val baseFileNames: List[String] = licenseFiles
+    .map(_.replaceAll(extensionRegExp,""))
+    .sortBy(identity).distinct
+
+}

--- a/src/test/scala/nl/knaw/dans/easy/licenses/TestFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/TestFixture.scala
@@ -1,18 +1,38 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.easy.licenses
 
 import java.io.File
 
 import org.scalatest.{ FlatSpec, Inspectors, Matchers }
 
-trait TestFixture extends FlatSpec with Matchers with Inspectors  {
+trait TestFixture extends FlatSpec with Matchers with Inspectors {
+
   val LICENSES_DIR = "src/main/resources/licenses"
-  val extensionRegExp = ".[^.]+$"
-  val licenseFiles: List[String] = new File(LICENSES_DIR)
+
+  val documentFiles: List[String] = new File(LICENSES_DIR)
     .listFiles.filter(_.isFile).map(_.getName)
     .filterNot(n => n.endsWith("properties") || n.endsWith("json"))
     .toList
-  val baseFileNames: List[String] = licenseFiles
-    .map(_.replaceAll(extensionRegExp,""))
+
+  val documentBaseFileNames: List[String] = documentFiles
+    .map(stripExtension)
     .sortBy(identity).distinct
 
+  def stripExtension(fileName: String): String = {
+    fileName.replaceAll(".[^.]+$", "")
+  }
 }

--- a/src/test/scala/nl/knaw/dans/easy/licenses/UrlSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/UrlSpec.scala
@@ -19,7 +19,7 @@ import scala.collection.JavaConverters._
 
 class UrlSpec extends LicenseJsonFixture with PropsFixture {
 
-  "all the urls in licenses.json" should "be present in the properties (not vice versa)" in {
+  "all the urls in licenses.json" should "be present in licenses.properties (not vice versa)" in {
     val propUrls: Seq[String] = props.getKeys.asScala.map(toBaseUrl).toList
     val jsonUrls: Seq[String] = jsonMap.keys.map(toBaseUrl).toSeq
 

--- a/src/test/scala/nl/knaw/dans/easy/licenses/UrlSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/licenses/UrlSpec.scala
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.licenses
+
+import scala.collection.JavaConverters._
+
+class UrlSpec extends LicenseJsonFixture with PropsFixture {
+
+  "all the urls in licenses.json" should "be present in the properties (not vice versa)" in {
+    val propUrls: Seq[String] = props.getKeys.asScala.map(toBaseUrl).toList
+    val jsonUrls: Seq[String] = jsonMap.keys.map(toBaseUrl).toSeq
+
+    forEvery(jsonUrls) { url => propUrls should contain(url) }
+  }
+
+  // external parties may change from http to https and/or drop/add www
+  // easy-deposit-agreement-creator is insensitive for these changes
+  // URLs with other protocols than http/https will remain as is
+  private def toBaseUrl(fileName: String) = {
+    fileName.replaceAll("https?://(www.)?", "")
+  }
+}


### PR DESCRIPTION
prepares for EASY-2429

#### When applied it will
* continues on #5
* have refactored and new test

#### Where should the reviewer @DANS-KNAW/easy start?


#### How should this be manually tested?


#### related pull requests on github
When merged _after_ #7 the keyword `pendingUntilFixed` should be dropped.
https://github.com/DANS-KNAW/easy-licenses/blob/a17c8e1a3c5d88f3315996f15322f4a58b4f9561/src/test/scala/nl/knaw/dans/easy/licenses/LicensesPropertiesSpec.scala#L39-L41