### PR TITLE
EASY-2474 Convert documentation to mkdocs

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+GH_ORG=DANS-KNAW
+
+set -e
+
+# Relies on Travis checking out repo to a dir with the repo's name.
+GH_REPO=$(basename $TRAVIS_BUILD_DIR)
+REMOTE="https://${GH_TOKEN}@github.com/${GH_ORG}/${GH_REPO}"
+git remote set-url origin ${REMOTE}
+
+echo "START installing required Python packages..."
+pip3 install mkdocs
+pip3 install pygments
+pip3 install pymdown-extensions
+pip3 install pyyaml
+pip3 install mkdocs-markdownextradata-plugin
+echo "DONE installing required Python packages."
+
+echo "START installing DANS mkdocs theme..."
+git clone https://github.com/Dans-labs/mkdocs-dans $HOME/mkdocs-dans
+pushd $HOME/mkdocs-dans
+git pull
+python3 build.py pack
+popd
+echo "DONE installing DANS mkdocs theme."
+
+echo "START deploying docs to GitHub pages..."
+mkdocs gh-deploy --force
+echo "DONE deploying docs to GitHub pages."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+matrix:
+  include:
+    - language: java
+      jdk: openjdk8
+      cache:
+        directories:
+          - "$HOME/.m2/repository"
+    - language: python
+      if: branch = master AND NOT type = pull_request
+      python: 3.7.1
+      cache:
+        directories:
+          - "$HOME/.cache"
+          - "$HOME/virtualenv"
+      script:
+        - "./.travis.sh"

--- a/README.md
+++ b/README.md
@@ -1,22 +1,10 @@
-# easy-licenses
+easy-licenses
+=============
+[![Build Status](https://travis-ci.org/DANS-KNAW/easy-licenses.png?branch=master)](https://travis-ci.org/DANS-KNAW/easy-licenses)
+
 EASY Licenses  
 
-Formatting
------------
+Welcome
+-------
 
-#### From .html to .txt
-
-1. Reformat html file (`Preference > Editor > Code Style > HTML > Hard wrap at '80'`)
-2. Use tool to extract text from html file (e.g. https://onlinetexttools.com/extract-text-from-html)
-3. Create new .txt file with the same name as the html file and paste extracted text
-4. Check numbering with rendered html page as reference
-5. Move all text to the left of the page (`Ctrl + Shift + Tab`)
-6. Manually add indentation with Tabs
-7. Do a final check with the html page as reference
-
-Note: Revert the changes to the html file before committing to VCS.
-
-#### From .pdf to .txt
-
-Copy text from pdf file and follow above steps 3 to 7.
-
+Welcome to the `easy-licenses` project. See the [GitHub pages](https://dans-knaw.github.io/easy-licenses/) for the manual.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,25 @@
+MANUAL
+======
+[![Build Status](https://travis-ci.org/DANS-KNAW/easy-licenses.png?branch=master)](https://travis-ci.org/DANS-KNAW/easy-licenses)
+
+EASY Licenses  
+
+Formatting
+-----------
+
+#### From .html to .txt
+
+1. Reformat html file (`Preference > Editor > Code Style > HTML > Hard wrap at '80'`)
+2. Use tool to extract text from html file (e.g. https://onlinetexttools.com/extract-text-from-html)
+3. Create new .txt file with the same name as the html file and paste extracted text
+4. Check numbering with rendered html page as reference
+5. Move all text to the left of the page (`Ctrl + Shift + Tab`)
+6. Manually add indentation with Tabs
+7. Do a final check with the html page as reference
+
+Note: Revert the changes to the html file before committing to VCS.
+
+#### From .pdf to .txt
+
+Copy text from pdf file and follow above steps 3 to 7.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2019 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+site_name: easy-licenses
+theme:
+  name: dans
+  disclaimer: false
+
+repo_name: DANS-KNAW/easy-licenses
+repo_url: https://github.com/DANS-KNAW/easy-licenses
+
+nav:
+  - Manual: index.md
+
+plugins:
+  - markdownextradata
+  - search
+
+markdown_extensions:
+  - attr_list
+  #- legacy_attr
+  - admonition
+  - codehilite:
+      guess_lang: false
+  - def_list
+  - footnotes
+  - meta
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.critic
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: Dans-labs
+      repo: mkdocs-dans
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde


### PR DESCRIPTION
fixes EASY-2474

#### When applied it will
* convert the project documentation to mkdocs format

#### Where should the reviewer @DANS-KNAW/easy start?
check out the project, run `mkdocs serve`

#### How should this be manually tested?
https://dans-labs.github.io/mkdocs-dans/